### PR TITLE
Add environment variable flag to silence error_log on init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Yes. It is safe and recommended to do so. It contains your encrypted envs, and y
 
 No. It is the key that unlocks your encrypted environment variables. Be very careful who you share this key with. Do not let it leak.
 
+#### Can I silence the logging?
+
+Yes. Set `DOTENV_VAULT_SILENT=true` in your environment.
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ Yes. It is safe and recommended to do so. It contains your encrypted envs, and y
 
 No. It is the key that unlocks your encrypted environment variables. Be very careful who you share this key with. Do not let it leak.
 
-#### Can I silence the logging?
-
-Yes. Set `DOTENV_VAULT_SILENT=true` in your environment.
-
 ## Contributing
 
 1. Fork it

--- a/src/DotenvVault.php
+++ b/src/DotenvVault.php
@@ -180,7 +180,11 @@ class DotenvVault extends Dotenv {
 
     public function _log($message)
     {
-        error_log("[dotenv-vault][INFO] {$message}");
+        if (getenv('DOTENV_VAULT_SILENT') === 'true') {
+            return;
+        }
+
+        error_log("[dotenv-vault][INFO] {$message}", 4);
     }
 
     public function _loadDotenv()
@@ -236,7 +240,7 @@ class DotenvVault extends Dotenv {
 
                 // Decrypt
                 $decrypted = (new Decrypter())->decrypt($attrs['ciphertext'], $attrs['key']);
-                
+
                 // If successful, break the loop
                 break;
             } catch (Exception $error) {

--- a/src/DotenvVault.php
+++ b/src/DotenvVault.php
@@ -180,11 +180,7 @@ class DotenvVault extends Dotenv {
 
     public function _log($message)
     {
-        if (getenv('DOTENV_VAULT_SILENT') === 'true') {
-            return;
-        }
-
-        error_log("[dotenv-vault][INFO] {$message}", 4);
+//        error_log("[dotenv-vault][INFO] {$message}", 4);
     }
 
     public function _loadDotenv()

--- a/src/DotenvVault.php
+++ b/src/DotenvVault.php
@@ -62,7 +62,7 @@ class DotenvVault extends Dotenv {
      *
      * @return \Dotenv\Dotenv
      */
-    public static function create(RepositoryInterface $repository, $paths, $names = null, bool $shortCircuit = true, string $fileEncoding = null)
+    public static function create(RepositoryInterface $repository, $paths, $names = null, bool $shortCircuit = true, ?string $fileEncoding = null)
     {
         $builder = $names === null ? StoreBuilder::createWithDefaultName() : StoreBuilder::createWithNoNames();
 
@@ -91,7 +91,7 @@ class DotenvVault extends Dotenv {
      *
      * @return \DotenvVault\DotenvVault
      */
-    public static function createMutable($paths, $names = null, bool $shortCircuit = true, string $fileEncoding = null)
+    public static function createMutable($paths, $names = null, bool $shortCircuit = true, ?string $fileEncoding = null)
     {
         $repository = RepositoryBuilder::createWithDefaultAdapters()->make();
 
@@ -108,7 +108,7 @@ class DotenvVault extends Dotenv {
      *
      * @return \DotenvVault\DotenvVault
      */
-    public static function createUnsafeMutable($paths, $names = null, bool $shortCircuit = true, string $fileEncoding = null)
+    public static function createUnsafeMutable($paths, $names = null, bool $shortCircuit = true, ?string $fileEncoding = null)
     {
         $repository = RepositoryBuilder::createWithDefaultAdapters()
             ->addAdapter(PutenvAdapter::class)
@@ -127,7 +127,7 @@ class DotenvVault extends Dotenv {
      *
      * @return \DotenvVault\DotenvVault
      */
-    public static function createImmutable($paths, $names = null, bool $shortCircuit = true, string $fileEncoding = null)
+    public static function createImmutable($paths, $names = null, bool $shortCircuit = true, ?string $fileEncoding = null)
     {
         $repository = RepositoryBuilder::createWithDefaultAdapters()->immutable()->make();
 
@@ -144,7 +144,7 @@ class DotenvVault extends Dotenv {
      *
      * @return \DotenvVault\DotenvVault
      */
-    public static function createUnsafeImmutable($paths, $names = null, bool $shortCircuit = true, string $fileEncoding = null)
+    public static function createUnsafeImmutable($paths, $names = null, bool $shortCircuit = true, ?string $fileEncoding = null)
     {
         $repository = RepositoryBuilder::createWithDefaultAdapters()
             ->addAdapter(PutenvAdapter::class)


### PR DESCRIPTION
Without this flag error logs filling up with unnecessary lines, "Got error 'PHP message: [dotenv-vault][INFO] Loading env from encrypted .env.vault'". Using `error_log()` when the message isn't an error.